### PR TITLE
Avoid redefining the base font

### DIFF
--- a/src/Nri/Stylers.elm
+++ b/src/Nri/Stylers.elm
@@ -5,6 +5,7 @@ module Nri.Stylers exposing (makeFont)
 
 -}
 import Css exposing (..)
+import Nri.Fonts
 
 
 {-|
@@ -13,7 +14,7 @@ takes a size and a color and creates a font
 makeFont : Css.FontSize a -> Css.ColorValue b -> Mixin
 makeFont size fontColor =
     mixin
-        [ Css.property "font-family" "\"Varela Round\", \"Gotham\", \"Helvetica Neue\", Helvetica, Arial, sans-serif"
+        [  Nri.Fonts.baseFont
         , fontSize size
         , color fontColor
         ]


### PR DESCRIPTION
Not sure what the ideal eventual api would be here, but we should be using baseFont.
