### PR TITLE
Bump maximum supported elm-css to 8.0.0

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.9.0",
+    "version": "1.9.1",
     "summary": "Helpers for working with NRI styling",
     "repository": "https://github.com/NoRedInk/nri-elm-css.git",
     "license": "BSD3",
@@ -16,7 +16,7 @@
     ],
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v < 6.0.0",
-        "rtfeldman/elm-css": "3.0.0 <= v < 8.0.0"
+        "rtfeldman/elm-css": "3.0.0 <= v < 9.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
`elm-css` 8.0.0 is out, and this is already compatible!