### PR TITLE
Add Nri.Colors.Deprecated for transitioning colors

### DIFF
--- a/src/Nri/Colors/Deprecated.elm
+++ b/src/Nri/Colors/Deprecated.elm
@@ -1,0 +1,27 @@
+module Nri.Colors.Deprecated
+    exposing
+        ( linkBlueSuperLight
+        )
+
+{-|
+
+
+## Deprecated Colors
+
+Colors listed below are in the process of being killed or renamed.
+@docs linkBlueSuperLight
+
+-}
+
+import Css exposing (hex, rgba)
+
+
+{-| This color is in use in some animations currently, but isn't in the
+current style guide.
+
+<p style="font-size:2em; color: #CBE4F5; background-color: black;">#CBE4F5</p>
+
+-}
+linkBlueSuperLight : Css.Color
+linkBlueSuperLight =
+    hex "#CBE4F5"


### PR DESCRIPTION
#### Context:

Adds a module for deprecated colors.

This might be useful for two things:
1. Retiring colors - if we have a module for deprecated colors we can retire them in three phases:
    a. Add the color to deprecated. Switch over all call-sites in the monolith at our leisure
    b. Once all callsites switched over, remove from Nri.Colors and leave only in Nri.Colors.Deprecated. At out leisure, replace the deprecated colors in the monolith.
    c. Once all callsites removed, remove from Nri.Colors.Deprecated.

2. Adding colors - if we find colors in use in the monolith, we can add them to deprecated to signal to design that we have unsanctioned colors in use. They'll be super visible this way, and design can decide how to deal with them (sanction them, replace with sanctioned color, etc...)

This came up because I ran across a color we're using in the monolith that is not sanctioned. I wanted to put it with all the rest of our colors but did not want to muddy up our sanctioned styles.