### PR TITLE
Version 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The hex code underneath should not change.
 | highlightSolidYellow           | yellow                            |
 | linkBlue                       | azure                             |
 | linkBlueDark                   | **azureDark** (see color changes) |
-| linkBlueLight                  | blueLighter                       |
+| linkBlueLight                  | **frost** (see color changes)     |
 | linkBlueMed                    | glacier                           |
 | orangeLighter                  | no equivalent color               |
 | orangeDark                     | **ochre** (see color changes)     |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Change Log
+
+## 5.0.0 26-October-2017
+
+### Breaking Changes
+
+**Deprecations:**  The following colors were moved to Deprecated.
+Use the new name, or import the Deprecated colors module.
+The hex code underneath should not change.
+
+| Nri.Colors.Deprecated function | Equivalent Nri.Colors function    |
+|--------------------------------|-----------------------------------|
+| black                          | gray80                            |
+| blueDark                       | navy                              |
+| blueDark5                      | frost                             |
+| blueDark70                     | navy                              |
+| blueLighter                    | **frost** (see color changes)     |
+| coral                          | red                               |
+| coralLighter                   | redLight                          |
+| coralLightest                  | redLight                          |
+| gray                           | gray75                            |
+| grayDark                       | gray45                            |
+| grayDarker                     | gray45                            |
+| grayLighter                    | gray92                            |
+| grayLightest                   | gray96                            |
+| greenLighter                   | greenLight                        |
+| highlightSolidBlue             | cyan                              |
+| highlightSolidMagenta          | magenta                           |
+| highlightSolidYellow           | yellow                            |
+| linkBlue                       | azure                             |
+| linkBlueDark                   | **azureDark** (see color changes) |
+| linkBlueLight                  | blueLighter                       |
+| linkBlueMed                    | glacier                           |
+| orangeLighter                  | no equivalent color               |
+| orangeDark                     | **ochre** (see color changes)     |
+| purpleLighter                  | purpleLight                       |
+| purpleLightest                 | purpleLight                       |
+| redLightest                    | redLight                          |
+| turquoiseLighter               | turquoiseLight                    |
+| turquoiseLightest              | turquoiseLight                    |
+| yellowDark                     | yellow                            |
+| yellowLight                    | sunshine                          |
+
+**Renamings:** The following colors were renamed.
+All callsites will need to be updated.
+
+| Old Nri.Colors function | New Nri.Colors function |
+|-------------------------|-------------------------|
+| gray80                  | gray20                  |
+| turquiseLight           | turquoiseLight          |
+
+
+**Color Changes:** The following colors' hex codes (appearance) changed:
+
+| Color         | Old value | New Value |
+|---------------|-----------|-----------|
+| blueLighter   | #e4eff5   | frost     |
+| green         | #00e541   | #00d93e   |
+| linkBlueDark  | #3a97cd   | azureDark |
+| navy          | #0e5595   | #004e95   |
+| orangeDark    | yellow    | ochre     |
+| turquoiseDark | #00a8a0   | #00a39b   |
+
+### Enhancements
+
+**withAlpha** A new function is available in Nri.Colors.Extra that applies an alpha value to a Css.Color.
+
+**ochre** A new color is available. Ochre's value is #e68800.

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.1.0",
+    "version": "5.0.0",
     "summary": "Helpers for working with NRI styling",
     "repository": "https://github.com/NoRedInk/nri-elm-css.git",
     "license": "BSD3",

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -5,16 +5,9 @@ module Nri.Colors
         , aquaLight
         , azure
         , azureDark
-        , black
         , blue
-        , blueDark
-        , blueDark5
-        , blueDark70
         , blueDeep
         , blueLighter
-        , coral
-        , coralLighter
-        , coralLightest
         , cornflower
         , cornflowerDark
         , cornflowerLight
@@ -22,33 +15,20 @@ module Nri.Colors
         , frost
         , glacier
         , grassland
-        , gray
         , gray45
         , gray75
         , gray80
         , gray92
         , gray96
-        , grayDark
-        , grayDarker
-        , grayLighter
-        , grayLightest
         , green
         , greenDark
         , greenDarkest
         , greenLight
-        , greenLighter
         , greenLightest
         , highlightLightBlue
         , highlightLightMagenta
         , highlightLightYellow
-        , highlightSolidBlue
-        , highlightSolidMagenta
-        , highlightSolidYellow
         , lichen
-        , linkBlue
-        , linkBlueDark
-        , linkBlueLight
-        , linkBlueMed
         , magenta
         , navy
         , orange
@@ -57,22 +37,15 @@ module Nri.Colors
         , purple
         , purpleDark
         , purpleLight
-        , purpleLighter
-        , purpleLightest
         , red
         , redDark
         , redLight
-        , redLightest
         , sunshine
         , turquoise
         , turquoiseDark
-        , turquoiseLighter
-        , turquoiseLightest
         , turquoiseLight
         , white
         , yellow
-        , yellowDark
-        , yellowLight
         )
 
 {-| Helper module for working with colors.
@@ -83,22 +56,22 @@ representation, consider converting css colors to core colors and then using
 to convert to string.
 
 @docs aqua, aquaDark, aquaLight, azure, azureDark
-@docs black, white
-@docs blue, blueDark, blueDark5, blueDark70, blueDeep, blueLighter
-@docs coral, coralLighter, coralLightest, cornflower, cornflowerDark, cornflowerLight, cyan
+@docs white
+@docs blue, blueDeep, blueLighter
+@docs cornflower, cornflowerDark, cornflowerLight, cyan
 @docs frost
-@docs gray, gray45, gray80, gray75, gray92, gray96, grayDark, grayDarker, grayLighter, grayLightest
-@docs glacier, grassland, green, greenDark, greenDarkest, greenLight, greenLighter, greenLightest
-@docs highlightLightBlue, highlightLightMagenta, highlightLightYellow, highlightSolidBlue, highlightSolidMagenta, highlightSolidYellow
-@docs lichen, linkBlue, linkBlueLight, linkBlueMed, linkBlueDark
+@docs gray45, gray80, gray75, gray92, gray96
+@docs glacier, grassland, green, greenDark, greenDarkest, greenLight, greenLightest
+@docs highlightLightBlue, highlightLightMagenta, highlightLightYellow
+@docs lichen
 @docs magenta
 @docs navy
 @docs orange, orangeDark, orangeLighter
-@docs purple, purpleDark, purpleLight, purpleLighter, purpleLightest
-@docs red, redDark, redLight, redLightest
+@docs purple, purpleDark, purpleLight
+@docs red, redDark, redLight
 @docs sunshine
-@docs turquoise, turquoiseDark, turquoiseLight, turquoiseLighter, turquoiseLightest
-@docs yellow, yellowDark, yellowLight
+@docs turquoise, turquoiseDark, turquoiseLight
+@docs yellow
 
 -}
 
@@ -157,52 +130,12 @@ azureDark =
 
 {-|
 
-<p style="font-size:2em; color: #333333">#333333</p>
-
--}
-black : Css.Color
-black =
-    gray80
-
-
-{-|
-
 <p style="font-size:2em; color: #40a8e4">#40a8e4</p>
 
 -}
 blue : Css.Color
 blue =
     hex "#40a8e4"
-
-
-{-|
-
-<p style="font-size:2em; color: #0e5595">#0e5595</p>
-
--}
-blueDark : Css.Color
-blueDark =
-    navy
-
-
-{-|
-
-<p style="font-size:2em; color: #eef9ff; background-color: black;">#eef9ff</p>
-
--}
-blueDark5 : Css.Color
-blueDark5 =
-    frost
-
-
-{-|
-
-<p style="font-size:2em; color: #0e5595">#0e5595</p>
-
--}
-blueDark70 : Css.Color
-blueDark70 =
-    navy
 
 
 {-|
@@ -223,36 +156,6 @@ blueDeep =
 blueLighter : Css.Color
 blueLighter =
     hex "#e4eff5"
-
-
-{-|
-
-<p style="font-size:2em; color: #F3336c">#F3336c</p>
-
--}
-coral : Css.Color
-coral =
-    red
-
-
-{-|
-
-<p style="font-size:2em; color: #ffe0e6; background-color: black;">#ffe0e6</p>
-
--}
-coralLighter : Css.Color
-coralLighter =
-    redLight
-
-
-{-|
-
-<p style="font-size:2em; color: #ffe0e6; background-color: black;">#ffe0e6</p>
-
--}
-coralLightest : Css.Color
-coralLightest =
-    redLight
 
 
 {-|
@@ -327,16 +230,6 @@ grassland =
 
 {-|
 
-<p style="font-size:2em; color: #bfbfbf; background-color: black;">#bfbfbf</p>
-
--}
-gray : Css.Color
-gray =
-    gray75
-
-
-{-|
-
 <p style="font-size:2em; color: #333333">#333333</p>
 
 -}
@@ -387,46 +280,6 @@ gray96 =
 
 {-|
 
-<p style="font-size:2em; color: #727272">#727272</p>
-
--}
-grayDark : Css.Color
-grayDark =
-    gray45
-
-
-{-|
-
-<p style="font-size:2em; color: #727272">#727272</p>
-
--}
-grayDarker : Css.Color
-grayDarker =
-    gray45
-
-
-{-|
-
-<p style="font-size:2em; color: #EBEBEB; background-color: black;">#EBEBEB</p>
-
--}
-grayLighter : Css.Color
-grayLighter =
-    gray92
-
-
-{-|
-
-<p style="font-size:2em; color: #f5f5f5; background-color: black;">#f5f5f5</p>
-
--}
-grayLightest : Css.Color
-grayLightest =
-    gray96
-
-
-{-|
-
 <p style="font-size:2em; color: #00e541">#00e541</p>
 
 -}
@@ -463,16 +316,6 @@ greenDarkest =
 greenLight : Css.Color
 greenLight =
     hex "b3ffc9"
-
-
-{-|
-
-<p style="font-size:2em; color: #b3ffc9; background-color: black;">#b3ffc9</p>
-
--}
-greenLighter : Css.Color
-greenLighter =
-    greenLight
 
 
 {-|
@@ -517,72 +360,12 @@ highlightLightYellow =
 
 {-|
 
-<p style="font-size:2em; color: #43dcff">#43dcff</p>
-
--}
-highlightSolidBlue : Css.Color
-highlightSolidBlue =
-    cyan
-
-
-{-|
-
-<p style="font-size:2em; color: #ff00bd">#ff00bd</p>
-
--}
-highlightSolidMagenta : Css.Color
-highlightSolidMagenta =
-    magenta
-
-
-{-|
-
-<p style="font-size:2em; color: #fec70a">#fec70a</p>
-
--}
-highlightSolidYellow : Css.Color
-highlightSolidYellow =
-    yellow
-
-
-{-|
-
 <p style="font-size:2em; color: #99bfa4">#99bfa4</p>
 
 -}
 lichen : Css.Color
 lichen =
     hex "#99bfa4"
-
-
-{-| main link and button color
-
-<p style="font-size:2em; color: #146aff">#146aff</p>
-
--}
-linkBlue : Css.Color
-linkBlue =
-    azure
-
-
-{-| input accent color, link and button color against dark backgrounds where main color does not have enough contrast
-
-<p style="font-size:2em; color: #E4EFF5; background-color: black;">#E4EFF5</p>
-
--}
-linkBlueLight : Css.Color
-linkBlueLight =
-    hex "#E4EFF5"
-
-
-{-| secondary color for cycling dots
-
-<p style="font-size:2em; color: #d4f0ff; background-color: black;">#d4f0ff</p>
-
--}
-linkBlueMed : Css.Color
-linkBlueMed =
-    glacier
 
 
 {-| mix($link-blue, black, 90%)
@@ -677,26 +460,6 @@ purpleDark =
 
 {-|
 
-<p style="font-size:2em; color: #f7ebff; background-color: black;">#f7ebff</p>
-
--}
-purpleLighter : Css.Color
-purpleLighter =
-    purpleLight
-
-
-{-|
-
-<p style="font-size:2em; color: #f7ebff; background-color: black;">#f7ebff</p>
-
--}
-purpleLightest : Css.Color
-purpleLightest =
-    purpleLight
-
-
-{-|
-
 <p style="font-size:2em; color: #f3336c">#f3336c</p>
 
 -}
@@ -723,16 +486,6 @@ redLight =
 redDark : Css.Color
 redDark =
     hex "#c2003a"
-
-
-{-|
-
-<p style="font-size:2em; color: #ffe0e6">#ffe0e6</p>
-
--}
-redLightest : Css.Color
-redLightest =
-    redLight
 
 
 {-|
@@ -777,26 +530,6 @@ turquoiseLight =
 
 {-|
 
-<p style="font-size:2em; color: #e0fffe; background-color: black;">#e0fffe</p>
-
--}
-turquoiseLighter : Css.Color
-turquoiseLighter =
-    turquoiseLight
-
-
-{-|
-
-<p style="font-size:2em; color: #e0fffe; background-color: black;">#e0fffe</p>
-
--}
-turquoiseLightest : Css.Color
-turquoiseLightest =
-    turquoiseLight
-
-
-{-|
-
 <p style="font-size:2em; color: #fff; background-color: black;">#fff</p>
 
 -}
@@ -813,23 +546,3 @@ white =
 yellow : Css.Color
 yellow =
     hex "FEC709"
-
-
-{-|
-
-<p style="font-size:2em; color: #FEC709; background-color: black;">#FEC709</p>
-
--}
-yellowDark : Css.Color
-yellowDark =
-    yellow
-
-
-{-|
-
-<p style="font-size:2em; color: #fffadc; background-color: black;">#fffadc</p>
-
--}
-yellowLight : Css.Color
-yellowLight =
-    sunshine

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -64,11 +64,11 @@ module Nri.Colors
         , redLight
         , redLightest
         , sunshine
-        , turquiseLight
         , turquoise
         , turquoiseDark
         , turquoiseLighter
         , turquoiseLightest
+        , turquoiseLight
         , white
         , yellow
         , yellowDark
@@ -97,7 +97,7 @@ to convert to string.
 @docs purple, purpleDark, purpleLight, purpleLighter, purpleLightest
 @docs red, redDark, redLight, redLightest
 @docs sunshine
-@docs turquoise, turquoiseDark, turquiseLight, turquoiseLighter, turquoiseLightest
+@docs turquoise, turquoiseDark, turquoiseLight, turquoiseLighter, turquoiseLightest
 @docs yellow, yellowDark, yellowLight
 
 -}
@@ -770,8 +770,8 @@ turquoiseDark =
 <p style="font-size:2em; color: #e0fffe">#e0fffe</p>
 
 -}
-turquiseLight : Css.Color
-turquiseLight =
+turquoiseLight : Css.Color
+turquoiseLight =
     hex "e0fffe"
 
 
@@ -782,7 +782,7 @@ turquiseLight =
 -}
 turquoiseLighter : Css.Color
 turquoiseLighter =
-    turquiseLight
+    turquoiseLight
 
 
 {-|
@@ -792,7 +792,7 @@ turquoiseLighter =
 -}
 turquoiseLightest : Css.Color
 turquoiseLightest =
-    turquiseLight
+    turquoiseLight
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -33,7 +33,6 @@ module Nri.Colors
         , navy
         , ochre
         , orange
-        , orangeLighter
         , purple
         , purpleDark
         , purpleLight
@@ -66,7 +65,7 @@ to convert to string.
 @docs lichen
 @docs magenta
 @docs navy
-@docs orange, ochre, orangeLighter
+@docs orange, ochre
 @docs purple, purpleDark, purpleLight
 @docs red, redDark, redLight
 @docs sunshine
@@ -416,16 +415,6 @@ orange =
 ochre : Css.Color
 ochre =
     hex "#e68800"
-
-
-{-|
-
-<p style="font-size:2em; color: #F9C97B; background-color: black;">#F9C97B</p>
-
--}
-orangeLighter : Css.Color
-orangeLighter =
-    hex "#F9C97B"
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -33,7 +33,6 @@ module Nri.Colors
         , navy
         , ochre
         , orange
-        , orangeDark
         , orangeLighter
         , purple
         , purpleDark
@@ -67,7 +66,7 @@ to convert to string.
 @docs lichen
 @docs magenta
 @docs navy
-@docs orange, ochre, orangeDark, orangeLighter
+@docs orange, ochre, orangeLighter
 @docs purple, purpleDark, purpleLight
 @docs red, redDark, redLight
 @docs sunshine
@@ -417,16 +416,6 @@ orange =
 ochre : Css.Color
 ochre =
     hex "#e68800"
-
-
-{-|
-
-<p style="font-size:2em; color: #e68800">#e68800</p>
-
--}
-orangeDark : Css.Color
-orangeDark =
-    ochre
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -114,7 +114,7 @@ aquaLight =
 -}
 azure : Css.Color
 azure =
-    hex "146aff"
+    hex "#146aff"
 
 
 {-|
@@ -127,7 +127,7 @@ azureDark =
     hex "#004cc9"
 
 
-{-|
+{-| TODO
 
 <p style="font-size:2em; color: #40a8e4">#40a8e4</p>
 
@@ -137,7 +137,7 @@ blue =
     hex "#40a8e4"
 
 
-{-|
+{-| TODO
 
 <p style="font-size:2em; color: #4a79a7">#4a79a7</p>
 
@@ -159,12 +159,12 @@ cornflower =
 
 {-|
 
-<p style="font-size:2em; color: #0074AD">#0074AD</p>
+<p style="font-size:2em; color: #0074ad">#0074ad</p>
 
 -}
 cornflowerDark : Css.Color
 cornflowerDark =
-    hex "#0074AD"
+    hex "#0074ad"
 
 
 {-|
@@ -184,7 +184,7 @@ cornflowerLight =
 -}
 cyan : Css.Color
 cyan =
-    hex "43dcff"
+    hex "#43dcff"
 
 
 {-|
@@ -194,7 +194,7 @@ cyan =
 -}
 frost : Css.Color
 frost =
-    hex "eef9ff"
+    hex "#eef9ff"
 
 
 {-|
@@ -204,7 +204,7 @@ frost =
 -}
 glacier : Css.Color
 glacier =
-    hex "d4f0ff"
+    hex "#d4f0ff"
 
 
 {-|
@@ -234,7 +234,7 @@ gray20 =
 -}
 gray45 : Css.Color
 gray45 =
-    hex "727272"
+    hex "#727272"
 
 
 {-|
@@ -244,7 +244,7 @@ gray45 =
 -}
 gray75 : Css.Color
 gray75 =
-    hex "bfbfbf"
+    hex "#bfbfbf"
 
 
 {-|
@@ -254,7 +254,7 @@ gray75 =
 -}
 gray92 : Css.Color
 gray92 =
-    hex "ebebeb"
+    hex "#ebebeb"
 
 
 {-|
@@ -279,12 +279,12 @@ green =
 
 {-|
 
-<p style="font-size:2em; color: #26A300">#26A300</p>
+<p style="font-size:2em; color: #26a300">#26a300</p>
 
 -}
 greenDark : Css.Color
 greenDark =
-    hex "#26A300"
+    hex "#26a300"
 
 
 {-|
@@ -304,7 +304,7 @@ greenDarkest =
 -}
 greenLight : Css.Color
 greenLight =
-    hex "b3ffc9"
+    hex "#b3ffc9"
 
 
 {-|
@@ -317,7 +317,7 @@ greenLightest =
     hex "#e6ffed"
 
 
-{-|
+{-| cyan with alpha of 0.75
 
 <p style="font-size:2em; color: rgba(66, 219, 255, 0.75)">rgba(66, 219, 255, 0.75)</p>
 
@@ -327,7 +327,7 @@ highlightLightBlue =
     withAlpha 0.75 cyan
 
 
-{-|
+{-| magenta with alpha of 0.5
 
 <p style="font-size:2em; color: rgba(255, 0 ,189, 0.5)">rgba(255, 0 ,189, 0.5)</p>
 
@@ -337,7 +337,7 @@ highlightLightMagenta =
     withAlpha 0.5 magenta
 
 
-{-|
+{-| yellow with alpha of 0.75
 
 <p style="font-size:2em; color: rgba(254, 199 ,9, 0.75)">rgba(254, 199 ,9, 0.75)</p>
 
@@ -357,14 +357,14 @@ lichen =
     hex "#99bfa4"
 
 
-{-| mix($link-blue, black, 90%)
+{-| TODO mix($link-blue, black, 90%)
 
-<p style="font-size:2em; color: #3A97CD">#3A97CD</p>
+<p style="font-size:2em; color: #3a97cd">#3a97cd</p>
 
 -}
 linkBlueDark : Css.Color
 linkBlueDark =
-    hex "#3A97CD"
+    hex "#3a97cd"
 
 
 {-|
@@ -374,7 +374,7 @@ linkBlueDark =
 -}
 magenta : Css.Color
 magenta =
-    hex "ff00bd"
+    hex "#ff00bd"
 
 
 {-|
@@ -387,14 +387,14 @@ navy =
     hex "#004e95"
 
 
-{-|
+{-| -- TODO
 
-<p style="font-size:2em; color: #F5A623">#F5A623</p>
+<p style="font-size:2em; color: #f5a623">#f5a623</p>
 
 -}
 orange : Css.Color
 orange =
-    hex "#F5A623"
+    hex "#f5a623"
 
 
 {-|
@@ -424,17 +424,17 @@ purple =
 -}
 purpleLight : Css.Color
 purpleLight =
-    hex "f7ebff"
+    hex "#f7ebff"
 
 
 {-|
 
-<p style="font-size:2em; color: #7721A7">#7721A7</p>
+<p style="font-size:2em; color: #7721a7">#7721a7</p>
 
 -}
 purpleDark : Css.Color
 purpleDark =
-    hex "#7721A7"
+    hex "#7721a7"
 
 
 {-|
@@ -454,7 +454,7 @@ red =
 -}
 redLight : Css.Color
 redLight =
-    hex "ffe0e6"
+    hex "#ffe0e6"
 
 
 {-|
@@ -474,7 +474,7 @@ redDark =
 -}
 sunshine : Css.Color
 sunshine =
-    hex "fffadc"
+    hex "#fffadc"
 
 
 {-|
@@ -489,12 +489,12 @@ turquoise =
 
 {-|
 
-<p style="font-size:2em; color: #00A39B">#00A39B</p>
+<p style="font-size:2em; color: #00a39b">#00a39b</p>
 
 -}
 turquoiseDark : Css.Color
 turquoiseDark =
-    hex "#00A39B"
+    hex "#00a39b"
 
 
 {-|
@@ -504,24 +504,24 @@ turquoiseDark =
 -}
 turquoiseLight : Css.Color
 turquoiseLight =
-    hex "e0fffe"
+    hex "#e0fffe"
 
 
 {-|
 
-<p style="font-size:2em; color: #fff; background-color: black;">#fff</p>
+<p style="font-size:2em; color: #ffffff; background-color: black;">#ffffff</p>
 
 -}
 white : Css.Color
 white =
-    hex "#fff"
+    hex "#ffffff"
 
 
 {-|
 
-<p style="font-size:2em; color: #FEC709">#FEC709</p>
+<p style="font-size:2em; color: #fec709">#fec709</p>
 
 -}
 yellow : Css.Color
 yellow =
-    hex "FEC709"
+    hex "#fec709"

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -264,17 +264,17 @@ gray92 =
 -}
 gray96 : Css.Color
 gray96 =
-    hex "f5f5f5"
+    hex "#f5f5f5"
 
 
 {-|
 
-<p style="font-size:2em; color: #00e541">#00e541</p>
+<p style="font-size:2em; color: #00d93e">#00d93e</p>
 
 -}
 green : Css.Color
 green =
-    hex "#00e541"
+    hex "#00d93e"
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -14,9 +14,9 @@ module Nri.Colors
         , frost
         , glacier
         , grassland
+        , gray20
         , gray45
         , gray75
-        , gray80
         , gray92
         , gray96
         , green
@@ -58,7 +58,7 @@ to convert to string.
 @docs blue, blueDeep
 @docs cornflower, cornflowerDark, cornflowerLight, cyan
 @docs frost
-@docs gray45, gray80, gray75, gray92, gray96
+@docs gray20, gray45, gray75, gray92, gray96
 @docs glacier, grassland, green, greenDark, greenDarkest, greenLight, greenLightest
 @docs highlightLightBlue, highlightLightMagenta, highlightLightYellow
 @docs lichen
@@ -222,9 +222,9 @@ grassland =
 <p style="font-size:2em; color: #333333">#333333</p>
 
 -}
-gray80 : Css.Color
-gray80 =
-    hex "333333"
+gray20 : Css.Color
+gray20 =
+    hex "#333333"
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -75,6 +75,7 @@ to convert to string.
 -}
 
 import Css exposing (hex, rgba)
+import Nri.Colors.Extra exposing (withAlpha)
 
 
 {-|
@@ -334,7 +335,7 @@ greenLightest =
 -}
 highlightLightBlue : Css.Color
 highlightLightBlue =
-    rgba 66 219 255 0.75
+    withAlpha 0.75 cyan
 
 
 {-|
@@ -344,7 +345,7 @@ highlightLightBlue =
 -}
 highlightLightMagenta : Css.Color
 highlightLightMagenta =
-    rgba 255 0 189 0.5
+    withAlpha 0.5 magenta
 
 
 {-|
@@ -354,7 +355,7 @@ highlightLightMagenta =
 -}
 highlightLightYellow : Css.Color
 highlightLightYellow =
-    rgba 254 199 9 0.75
+    withAlpha 0.75 yellow
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -500,12 +500,12 @@ turquoise =
 
 {-|
 
-<p style="font-size:2em; color: #00A8A0">#00A8A0</p>
+<p style="font-size:2em; color: #00A39B">#00A39B</p>
 
 -}
 turquoiseDark : Css.Color
 turquoiseDark =
-    hex "#00A8A0"
+    hex "#00A39B"
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -7,7 +7,6 @@ module Nri.Colors
         , azureDark
         , blue
         , blueDeep
-        , blueLighter
         , cornflower
         , cornflowerDark
         , cornflowerLight
@@ -56,7 +55,7 @@ to convert to string.
 
 @docs aqua, aquaDark, aquaLight, azure, azureDark
 @docs white
-@docs blue, blueDeep, blueLighter
+@docs blue, blueDeep
 @docs cornflower, cornflowerDark, cornflowerLight, cyan
 @docs frost
 @docs gray45, gray80, gray75, gray92, gray96
@@ -146,16 +145,6 @@ blue =
 blueDeep : Css.Color
 blueDeep =
     hex "#4a79a7"
-
-
-{-|
-
-<p style="font-size:2em; color: #e4eff5; background-color: black;">#e4eff5</p>
-
--}
-blueLighter : Css.Color
-blueLighter =
-    hex "#e4eff5"
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -390,12 +390,12 @@ magenta =
 
 {-|
 
-<p style="font-size:2em; color: #0e5595">#0e5595</p>
+<p style="font-size:2em; color: #004e95">#004e95</p>
 
 -}
 navy : Css.Color
 navy =
-    hex "0e5595"
+    hex "#004e95"
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -421,12 +421,12 @@ ochre =
 
 {-|
 
-<p style="font-size:2em; color: #FEC709">#FEC709</p>
+<p style="font-size:2em; color: #e68800">#e68800</p>
 
 -}
 orangeDark : Css.Color
 orangeDark =
-    yellow
+    ochre
 
 
 {-|

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -357,16 +357,6 @@ lichen =
     hex "#99bfa4"
 
 
-{-| TODO mix($link-blue, black, 90%)
-
-<p style="font-size:2em; color: #3a97cd">#3a97cd</p>
-
--}
-linkBlueDark : Css.Color
-linkBlueDark =
-    hex "#3a97cd"
-
-
 {-|
 
 <p style="font-size:2em; color: #ff00bd">#ff00bd</p>

--- a/src/Nri/Colors.elm
+++ b/src/Nri/Colors.elm
@@ -31,6 +31,7 @@ module Nri.Colors
         , lichen
         , magenta
         , navy
+        , ochre
         , orange
         , orangeDark
         , orangeLighter
@@ -66,7 +67,7 @@ to convert to string.
 @docs lichen
 @docs magenta
 @docs navy
-@docs orange, orangeDark, orangeLighter
+@docs orange, ochre, orangeDark, orangeLighter
 @docs purple, purpleDark, purpleLight
 @docs red, redDark, redLight
 @docs sunshine
@@ -406,6 +407,16 @@ navy =
 orange : Css.Color
 orange =
     hex "#F5A623"
+
+
+{-|
+
+<p style="font-size:2em; color: #e68800">#e68800</p>
+
+-}
+ochre : Css.Color
+ochre =
+    hex "#e68800"
 
 
 {-|

--- a/src/Nri/Colors/Deprecated.elm
+++ b/src/Nri/Colors/Deprecated.elm
@@ -4,6 +4,7 @@ module Nri.Colors.Deprecated
         , blueDark
         , blueDark5
         , blueDark70
+        , blueLighter
         , coral
         , coralLighter
         , coralLightest
@@ -45,7 +46,7 @@ Renamed colors. Use the new name
 @docs black, gray, grayDark, grayDarker, grayLighter, grayLightest
 @docs greenLighter
 @docs highlightSolidBlue, highlightSolidMagenta, highlightSolidYellow
-@docs blueDark, blueDark5, blueDark70, linkBlue, linkBlueLight, linkBlueMed
+@docs blueDark, blueDark5, blueDark70, blueLighter, linkBlue, linkBlueLight, linkBlueMed
 @docs orangeDark
 @docs purpleLighter, purpleLightest
 @docs turquoiseLighter, turquoiseLightest
@@ -95,6 +96,16 @@ blueDark5 =
 blueDark70 : Css.Color
 blueDark70 =
     navy
+
+
+{-|
+
+<p style="font-size:2em; color: #eef9ff; background-color: black;">#eef9ff</p>
+
+-}
+blueLighter : Css.Color
+blueLighter =
+    frost
 
 
 {-| coral is now red

--- a/src/Nri/Colors/Deprecated.elm
+++ b/src/Nri/Colors/Deprecated.elm
@@ -58,14 +58,14 @@ import Css exposing (hex, rgba)
 import Nri.Colors exposing (..)
 
 
-{-| black is now gray80
+{-| black is now gray20
 
 <p style="font-size:2em; color: #333333">#333333</p>
 
 -}
 black : Css.Color
 black =
-    gray80
+    gray20
 
 
 {-| blueDark is now navy

--- a/src/Nri/Colors/Deprecated.elm
+++ b/src/Nri/Colors/Deprecated.elm
@@ -1,6 +1,32 @@
 module Nri.Colors.Deprecated
     exposing
-        ( linkBlueSuperLight
+        ( black
+        , blueDark
+        , blueDark5
+        , blueDark70
+        , coral
+        , coralLighter
+        , coralLightest
+        , gray
+        , grayDark
+        , grayDarker
+        , grayLighter
+        , grayLightest
+        , greenLighter
+        , highlightSolidBlue
+        , highlightSolidMagenta
+        , highlightSolidYellow
+        , linkBlue
+        , linkBlueLight
+        , linkBlueMed
+        , linkBlueSuperLight
+        , purpleLighter
+        , purpleLightest
+        , redLightest
+        , turquoiseLighter
+        , turquoiseLightest
+        , yellowDark
+        , yellowLight
         )
 
 {-|
@@ -11,12 +37,219 @@ module Nri.Colors.Deprecated
 Colors listed below are in the process of being killed or renamed.
 @docs linkBlueSuperLight
 
+Renamed colors. Use the new name
+@docs coral, coralLighter, coralLightest, redLightest
+@docs black, gray, grayDark, grayDarker, grayLighter, grayLightest
+@docs greenLighter
+@docs highlightSolidBlue, highlightSolidMagenta, highlightSolidYellow
+@docs blueDark, blueDark5, blueDark70, linkBlue, linkBlueLight, linkBlueMed
+@docs purpleLighter, purpleLightest
+@docs turquoiseLighter, turquoiseLightest
+@docs yellowDark, yellowLight
+
 -}
 
 import Css exposing (hex, rgba)
+import Nri.Colors exposing (..)
 
 
-{-| This color is in use in some animations currently, but isn't in the
+{-| black is now gray80
+
+<p style="font-size:2em; color: #333333">#333333</p>
+
+-}
+black : Css.Color
+black =
+    gray80
+
+
+{-| blueDark is now navy
+
+<p style="font-size:2em; color: #0e5595">#0e5595</p>
+
+-}
+blueDark : Css.Color
+blueDark =
+    navy
+
+
+{-| blueDark5 is now frost
+
+<p style="font-size:2em; color: #eef9ff; background-color: black;">#eef9ff</p>
+
+-}
+blueDark5 : Css.Color
+blueDark5 =
+    frost
+
+
+{-| blueDark70 is now navy
+
+<p style="font-size:2em; color: #0e5595">#0e5595</p>
+
+-}
+blueDark70 : Css.Color
+blueDark70 =
+    navy
+
+
+{-| coral is now red
+
+<p style="font-size:2em; color: #F3336c">#F3336c</p>
+
+-}
+coral : Css.Color
+coral =
+    red
+
+
+{-| coralLighter is now redLight
+
+<p style="font-size:2em; color: #ffe0e6; background-color: black;">#ffe0e6</p>
+
+-}
+coralLighter : Css.Color
+coralLighter =
+    redLight
+
+
+{-| coralLightest is now redLight
+
+<p style="font-size:2em; color: #ffe0e6; background-color: black;">#ffe0e6</p>
+
+-}
+coralLightest : Css.Color
+coralLightest =
+    redLight
+
+
+{-| gray is now gray75
+
+<p style="font-size:2em; color: #bfbfbf; background-color: black;">#bfbfbf</p>
+
+-}
+gray : Css.Color
+gray =
+    gray75
+
+
+{-| grayDark is now gray45
+
+<p style="font-size:2em; color: #727272">#727272</p>
+
+-}
+grayDark : Css.Color
+grayDark =
+    gray45
+
+
+{-| grayDarker is now gray45
+
+<p style="font-size:2em; color: #727272">#727272</p>
+
+-}
+grayDarker : Css.Color
+grayDarker =
+    gray45
+
+
+{-| grayLighter is now gray92
+
+<p style="font-size:2em; color: #EBEBEB; background-color: black;">#EBEBEB</p>
+
+-}
+grayLighter : Css.Color
+grayLighter =
+    gray92
+
+
+{-| grayLightest is now gray96
+
+<p style="font-size:2em; color: #f5f5f5; background-color: black;">#f5f5f5</p>
+
+-}
+grayLightest : Css.Color
+grayLightest =
+    gray96
+
+
+{-| greenLighter is now greenLight
+
+<p style="font-size:2em; color: #b3ffc9; background-color: black;">#b3ffc9</p>
+
+-}
+greenLighter : Css.Color
+greenLighter =
+    greenLight
+
+
+{-| highlightSolidBlue is now cyan
+
+<p style="font-size:2em; color: #43dcff">#43dcff</p>
+
+-}
+highlightSolidBlue : Css.Color
+highlightSolidBlue =
+    cyan
+
+
+{-| highlightSolidMagenta is now magenta
+
+<p style="font-size:2em; color: #ff00bd">#ff00bd</p>
+
+-}
+highlightSolidMagenta : Css.Color
+highlightSolidMagenta =
+    magenta
+
+
+{-| highlightSolidYellow is now yellow
+
+<p style="font-size:2em; color: #fec70a">#fec70a</p>
+
+-}
+highlightSolidYellow : Css.Color
+highlightSolidYellow =
+    yellow
+
+
+{-| linkBlue is now azure
+
+main link and button color
+
+<p style="font-size:2em; color: #146aff">#146aff</p>
+
+-}
+linkBlue : Css.Color
+linkBlue =
+    azure
+
+
+{-| linkBlueLight is now blueLighter
+
+input accent color, link and button color against dark backgrounds where main color does not have enough contrast
+
+<p style="font-size:2em; color: #E4EFF5; background-color: black;">#E4EFF5</p>
+
+-}
+linkBlueLight : Css.Color
+linkBlueLight =
+    blueLighter
+
+
+{-| linkBlueMed is now glacier
+
+secondary color for cycling dots
+
+<p style="font-size:2em; color: #d4f0ff; background-color: black;">#d4f0ff</p>
+
+-}
+linkBlueMed : Css.Color
+linkBlueMed =
+    glacier
+
+
+{-| linkBlueSuperLight is in use in some animations currently, but isn't in the
 current style guide.
 
 <p style="font-size:2em; color: #CBE4F5; background-color: black;">#CBE4F5</p>
@@ -25,3 +258,73 @@ current style guide.
 linkBlueSuperLight : Css.Color
 linkBlueSuperLight =
     hex "#CBE4F5"
+
+
+{-| purpleLighter is now purpleLight
+
+<p style="font-size:2em; color: #f7ebff; background-color: black;">#f7ebff</p>
+
+-}
+purpleLighter : Css.Color
+purpleLighter =
+    purpleLight
+
+
+{-| purpleLightest is now purpleLight
+
+<p style="font-size:2em; color: #f7ebff; background-color: black;">#f7ebff</p>
+
+-}
+purpleLightest : Css.Color
+purpleLightest =
+    purpleLight
+
+
+{-| redLightest is now redLight
+
+<p style="font-size:2em; color: #ffe0e6">#ffe0e6</p>
+
+-}
+redLightest : Css.Color
+redLightest =
+    redLight
+
+
+{-| turquoiseLighter is now turquoiseLight
+
+<p style="font-size:2em; color: #e0fffe; background-color: black;">#e0fffe</p>
+
+-}
+turquoiseLighter : Css.Color
+turquoiseLighter =
+    turquoiseLight
+
+
+{-| turquoiseLightest is now turquoiseLight
+
+<p style="font-size:2em; color: #e0fffe; background-color: black;">#e0fffe</p>
+
+-}
+turquoiseLightest : Css.Color
+turquoiseLightest =
+    turquoiseLight
+
+
+{-| yellowDark is now yellow
+
+<p style="font-size:2em; color: #FEC709; background-color: black;">#FEC709</p>
+
+-}
+yellowDark : Css.Color
+yellowDark =
+    yellow
+
+
+{-| yellowLight is now sunshine
+
+<p style="font-size:2em; color: #fffadc; background-color: black;">#fffadc</p>
+
+-}
+yellowLight : Css.Color
+yellowLight =
+    sunshine

--- a/src/Nri/Colors/Deprecated.elm
+++ b/src/Nri/Colors/Deprecated.elm
@@ -20,6 +20,7 @@ module Nri.Colors.Deprecated
         , linkBlueLight
         , linkBlueMed
         , linkBlueSuperLight
+        , orangeDark
         , purpleLighter
         , purpleLightest
         , redLightest
@@ -43,6 +44,7 @@ Renamed colors. Use the new name
 @docs greenLighter
 @docs highlightSolidBlue, highlightSolidMagenta, highlightSolidYellow
 @docs blueDark, blueDark5, blueDark70, linkBlue, linkBlueLight, linkBlueMed
+@docs orangeDark
 @docs purpleLighter, purpleLightest
 @docs turquoiseLighter, turquoiseLightest
 @docs yellowDark, yellowLight
@@ -258,6 +260,16 @@ current style guide.
 linkBlueSuperLight : Css.Color
 linkBlueSuperLight =
     hex "#CBE4F5"
+
+
+{-| orangeDark is now ochre
+
+<p style="font-size:2em; color: #e68800">#e68800</p>
+
+-}
+orangeDark : Css.Color
+orangeDark =
+    ochre
 
 
 {-| purpleLighter is now purpleLight

--- a/src/Nri/Colors/Deprecated.elm
+++ b/src/Nri/Colors/Deprecated.elm
@@ -21,6 +21,7 @@ module Nri.Colors.Deprecated
         , linkBlueMed
         , linkBlueSuperLight
         , orangeDark
+        , orangeLighter
         , purpleLighter
         , purpleLightest
         , redLightest
@@ -37,6 +38,7 @@ module Nri.Colors.Deprecated
 
 Colors listed below are in the process of being killed or renamed.
 @docs linkBlueSuperLight
+@docs orangeLighter
 
 Renamed colors. Use the new name
 @docs coral, coralLighter, coralLightest, redLightest
@@ -270,6 +272,16 @@ linkBlueSuperLight =
 orangeDark : Css.Color
 orangeDark =
     ochre
+
+
+{-| orangeLighter is not in the style guide, nor in the code base
+
+<p style="font-size:2em; color: #F9C97B; background-color: black;">#F9C97B</p>
+
+-}
+orangeLighter : Css.Color
+orangeLighter =
+    hex "#F9C97B"
 
 
 {-| purpleLighter is now purpleLight

--- a/src/Nri/Colors/Deprecated.elm
+++ b/src/Nri/Colors/Deprecated.elm
@@ -18,6 +18,7 @@ module Nri.Colors.Deprecated
         , highlightSolidMagenta
         , highlightSolidYellow
         , linkBlue
+        , linkBlueDark
         , linkBlueLight
         , linkBlueMed
         , linkBlueSuperLight
@@ -46,7 +47,7 @@ Renamed colors. Use the new name
 @docs black, gray, grayDark, grayDarker, grayLighter, grayLightest
 @docs greenLighter
 @docs highlightSolidBlue, highlightSolidMagenta, highlightSolidYellow
-@docs blueDark, blueDark5, blueDark70, blueLighter, linkBlue, linkBlueLight, linkBlueMed
+@docs blueDark, blueDark5, blueDark70, blueLighter, linkBlue, linkBlueDark, linkBlueLight, linkBlueMed
 @docs orangeDark
 @docs purpleLighter, purpleLightest
 @docs turquoiseLighter, turquoiseLightest
@@ -238,6 +239,16 @@ main link and button color
 linkBlue : Css.Color
 linkBlue =
     azure
+
+
+{-| linkBlueDark is now azureDark
+
+<p style="font-size:2em; color: #004cc9">#004cc9</p>
+
+-}
+linkBlueDark : Css.Color
+linkBlueDark =
+    azureDark
 
 
 {-| linkBlueLight is now blueLighter

--- a/src/Nri/Colors/Extra.elm
+++ b/src/Nri/Colors/Extra.elm
@@ -1,11 +1,11 @@
-module Nri.Colors.Extra exposing (..)
+module Nri.Colors.Extra exposing (toCoreColor, withAlpha)
 
 {-| Helpers for working with colors. Put color definitions in Nri.Colors itself.
 
 
 # Conversions
 
-@docs toCoreColor
+@docs toCoreColor, withAlpha
 
 -}
 
@@ -21,3 +21,14 @@ import Css exposing (..)
 toCoreColor : Css.Color -> Color.Color
 toCoreColor cssColor =
     Color.rgba cssColor.red cssColor.green cssColor.blue cssColor.alpha
+
+
+{-| Add an alpha property to a Css.Color
+
+    grassland -- "{ value = "#56bf74", color = Compatible, red = 86, green = 191, blue = 116, alpha = 1, warnings = [] } : Css.Color"
+    withAlpha 0.5 grassland -- "{ value = "rgba(86, 191, 116, 0.5)", color = Compatible, warnings = [], red = 86, green = 191, blue = 116, alpha = 0.5 } : Css.Color"
+
+-}
+withAlpha : Float -> Css.Color -> Css.Color
+withAlpha alpha { red, green, blue } =
+    Css.rgba red green blue alpha


### PR DESCRIPTION
This PR makes a bunch of changes to colors to bring us into alignment with the style guide.

Please read the [changelog file](https://github.com/NoRedInk/nri-elm-css/blob/4ccffeec44263cb6268020c8801332dd806c7cd7/CHANGELOG.md) added in this PR to get a sense for what happened here.

The only things not mentioned in the changelog were internal changes, like grooming of literal string hex codes to all start with a hash and be lowercase and the definition of the highlight transparent colors in terms of their base color and alpha.

Fixes #35 